### PR TITLE
fix: interface spelling

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ plugs:
     interface: system-files
     write:
       - "/sys/bus/vmbus/devices"
-  sys-LNXSYSTEM00:
+  sys-LNXSYSTM00:
     interface: system-files
     write:
       - "/sys/devices/LNXSYSTM:00"


### PR DESCRIPTION
When the system-files interaces were split by convention, one was incorrectly named.