### PR TITLE
fix: rename plug to lowercase

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ plugs:
     interface: system-files
     write:
       - "/sys/bus/vmbus/devices"
-  sys-devices-LNXSYSTM00:
+  sys-devices-lnxsystm00:
     interface: system-files
     write:
       - "/sys/devices/LNXSYSTM:00"


### PR DESCRIPTION
snapd performs install-time validation [0] which is bypassed by the `--dangerous` flag, which up until now has been required for testing the waagent snap prior to its upload to the store. Consequently, the Ubuntu Core image built using the model assertion will not bypass validation when installing the waagent snap, and the sys-devices-LNXSYSTM00 plug will fail validation and be disabled by snapd.

Refs: [0] https://github.com/canonical/snapd/blob/4d4006f083a6bb1b0322a51b57d7e2471ed04d9d/snap/naming/validate.go#L90